### PR TITLE
Support multiple recipients

### DIFF
--- a/docs/resources/email.md
+++ b/docs/resources/email.md
@@ -24,7 +24,6 @@ description: |-
 - `smtp_server` (String)
 - `smtp_username` (String)
 - `subject` (String)
-- `to_list` (List of String)
 
 ### Optional
 
@@ -34,6 +33,7 @@ description: |-
 - `reply_to` (String)
 - `to` (String, Deprecated)
 - `to_display_name` (String)
+- `to_list` (List of String)
 
 ### Read-Only
 

--- a/docs/resources/email.md
+++ b/docs/resources/email.md
@@ -24,7 +24,7 @@ description: |-
 - `smtp_server` (String)
 - `smtp_username` (String)
 - `subject` (String)
-- `to` (String)
+- `to_list` (List of String)
 
 ### Optional
 
@@ -32,6 +32,7 @@ description: |-
 - `from_display_name` (String)
 - `preamble` (String)
 - `reply_to` (String)
+- `to` (String, Deprecated)
 - `to_display_name` (String)
 
 ### Read-Only

--- a/email/provider_test.go
+++ b/email/provider_test.go
@@ -26,7 +26,9 @@ func TestAccEmail_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEmailExists("email_email.example"),
 					resource.TestCheckResourceAttr(
-						"email_email.example", "to", "recipient@example.com"),
+						"email_email.example", "to.#", "1"),
+					resource.TestCheckResourceAttr(
+						"email_email.example", "to.0", "recipient@example.com"),
 					resource.TestCheckResourceAttr(
 						"email_email.example", "from", "sender@example.com"),
 					resource.TestCheckResourceAttr(
@@ -115,7 +117,7 @@ func TestRetryWorkflow(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			// set test retries zero before each test
 			sendMailInvocations = 0
-			err := sendMail(test.sendMailFunc, maxRetries, "localhost", "2525", "username", "password", "from@example.com", "to@example.com", "message")
+			err := sendMail(test.sendMailFunc, maxRetries, "localhost", "2525", "username", "password", "from@example.com", []string{"to@example.com"}, "message")
 			if test.expectedErr != nil {
 				// assert that the errors are equal
 				assert.EqualError(t, err, test.expectedErr.Error())
@@ -132,7 +134,7 @@ func TestRetryWorkflow(t *testing.T) {
 // `docker run --rm -it -p 3000:80 -p 2525:25 rnwood/smtp4dev:v3`
 const testAccEmailConfig = `
 resource "email_email" "example" {
-	to = "recipient@example.com"
+	to = ["recipient@example.com"]
 	from = "sender@example.com"
 	reply_to = "reply_to@example.com"
 	subject = "Test Subject"

--- a/email/provider_test.go
+++ b/email/provider_test.go
@@ -26,9 +26,9 @@ func TestAccEmail_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEmailExists("email_email.example"),
 					resource.TestCheckResourceAttr(
-						"email_email.example", "to.#", "1"),
+						"email_email.example", "to_list.#", "1"),
 					resource.TestCheckResourceAttr(
-						"email_email.example", "to.0", "recipient@example.com"),
+						"email_email.example", "to_list.0", "recipient@example.com"),
 					resource.TestCheckResourceAttr(
 						"email_email.example", "from", "sender@example.com"),
 					resource.TestCheckResourceAttr(
@@ -134,7 +134,7 @@ func TestRetryWorkflow(t *testing.T) {
 // `docker run --rm -it -p 3000:80 -p 2525:25 rnwood/smtp4dev:v3`
 const testAccEmailConfig = `
 resource "email_email" "example" {
-	to = ["recipient@example.com"]
+	to_list = ["recipient@example.com"]
 	from = "sender@example.com"
 	reply_to = "reply_to@example.com"
 	subject = "Test Subject"

--- a/email/resource_email.go
+++ b/email/resource_email.go
@@ -96,7 +96,11 @@ func extractStatusCode(errMsg string) string {
 }
 
 func resourceEmailCreate(d *schema.ResourceData, m interface{}) error {
-	to := d.Get("to").([]string)
+	rawTo := d.Get("to").([]interface{})
+	to := make([]string, len(rawTo))
+	for i, v := range rawTo {
+		to[i] = v.(string)
+	}
 	toDisplayName := d.Get("to_display_name").(string)
 	from := d.Get("from").(string)
 	fromDisplayName := d.Get("from_display_name").(string)

--- a/email/resource_email.go
+++ b/email/resource_email.go
@@ -111,7 +111,7 @@ func resourceEmailCreate(d *schema.ResourceData, m interface{}) error {
 		rawTo, ok := d.GetOk("to")
 		if !ok {
 			// raise exception
-			return errors.New("`to` or `to_list` must be set")
+			return errors.New("`to` or `to_list` must be specified")
 		}
 		rawToList = []interface{}{rawTo}
 	}
@@ -119,6 +119,11 @@ func resourceEmailCreate(d *schema.ResourceData, m interface{}) error {
 	for i, v := range rawToList.([]interface{}) {
 		to[i] = v.(string)
 	}
+
+	if len(to) == 0 {
+		return errors.New("at least one recipient must be specified")
+	}
+
 	toDisplayName := d.Get("to_display_name").(string)
 	from := d.Get("from").(string)
 	fromDisplayName := d.Get("from_display_name").(string)

--- a/email/resource_email.go
+++ b/email/resource_email.go
@@ -17,6 +17,8 @@ type SendMailFunc func(addr string, a smtp.Auth, from string, to []string, msg [
 
 func resourceEmail() *schema.Resource {
 	return &schema.Resource{
+		SchemaVersion: 1,
+
 		Create: resourceEmailCreate,
 		Read:   resourceEmailRead,
 		Update: resourceEmailUpdate,
@@ -24,6 +26,11 @@ func resourceEmail() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"to": &schema.Schema{
+				Type:       schema.TypeString,
+				Optional:   true,
+				Deprecated: "Use `to_list` instead",
+			},
+			"to_list": &schema.Schema{
 				Type:     schema.TypeList,
 				Required: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
@@ -96,7 +103,7 @@ func extractStatusCode(errMsg string) string {
 }
 
 func resourceEmailCreate(d *schema.ResourceData, m interface{}) error {
-	rawTo := d.Get("to").([]interface{})
+	rawTo := d.Get("to_list").([]interface{})
 	to := make([]string, len(rawTo))
 	for i, v := range rawTo {
 		to[i] = v.(string)

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -11,7 +11,7 @@ provider "email" {}
 
 
 resource "email_email" "example" {
-  to = ["infra-outreach@watonomous.ca"]
+  to_list = ["infra-outreach@watonomous.ca"]
   to_display_name = "Infrastructure Outreach <infra-outreach@watonomous.ca>"
   from = "sentry-outgoing@watonomous.ca"
   from_display_name = "Sentry Outgoing <sentry-outgoing@watonomous.ca>"
@@ -27,7 +27,7 @@ resource "email_email" "example" {
 }
 
 resource "email_email" "example_with_styling" {
-  to = ["infra-outreach@watonomous.ca"]
+  to_list = ["infra-outreach@watonomous.ca"]
   to_display_name = "Infrastructure Outreach <infra-outreach@watonomous.ca>"
   from = "sentry-outgoing@watonomous.ca"
   from_display_name = "Sentry Outgoing <sentry-outgoing@watonomous.ca>"

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -11,7 +11,7 @@ provider "email" {}
 
 
 resource "email_email" "example" {
-  to = "infra-outreach@watonomous.ca"
+  to = ["infra-outreach@watonomous.ca"]
   to_display_name = "Infrastructure Outreach <infra-outreach@watonomous.ca>"
   from = "sentry-outgoing@watonomous.ca"
   from_display_name = "Sentry Outgoing <sentry-outgoing@watonomous.ca>"
@@ -27,7 +27,7 @@ resource "email_email" "example" {
 }
 
 resource "email_email" "example_with_styling" {
-  to = "infra-outreach@watonomous.ca"
+  to = ["infra-outreach@watonomous.ca"]
   to_display_name = "Infrastructure Outreach <infra-outreach@watonomous.ca>"
   from = "sentry-outgoing@watonomous.ca"
   from_display_name = "Sentry Outgoing <sentry-outgoing@watonomous.ca>"


### PR DESCRIPTION
This PR implements support for multiple recipients via a new `to_list` field that replaces the `to` field. This is natively supported by the `smtp.SendMail` function.